### PR TITLE
Allow configuration of SF authentication token type

### DIFF
--- a/src/CometD.NetCore.Salesforce/ResilientStreamingClient.cs
+++ b/src/CometD.NetCore.Salesforce/ResilientStreamingClient.cs
@@ -215,7 +215,7 @@ namespace CometD.NetCore.Salesforce
             var serverUri = new Uri(accessToken.InstanceUrl);
             var endpoint = $"{serverUri.Scheme}://{serverUri.Host}{_options.CometDUri}";
 
-            var headers = new NameValueCollection { { nameof(HttpRequestHeader.Authorization), $"OAuth {accessToken.AccessToken}" } };
+            var headers = new NameValueCollection { { nameof(HttpRequestHeader.Authorization), $"{_options.TokenType} {accessToken.AccessToken}" } };
 
             // Salesforce socket timeout during connection(CometD session) = 110 seconds
             var options = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)

--- a/src/CometD.NetCore.Salesforce/SalesforceConfiguration.cs
+++ b/src/CometD.NetCore.Salesforce/SalesforceConfiguration.cs
@@ -83,5 +83,10 @@ namespace CometD.NetCore.Salesforce
         /// Long polling duration. Default  120 * 1000.
         /// </summary>
         public long? ReadTimeOut { get; set; }
+
+        /// <summary>
+        /// The type of the Salesforce authentication token. Default "OAuth".
+        /// </summary>
+        public string TokenType { get; set; } = "OAuth";
     }
 }


### PR DESCRIPTION
This PR will allow the Salesforce authentication token type to be configurable. The default is still `OAuth`, so nothing will change for existing users of this library, but its value can be overwritten to something else e.g. `Bearer`