### PR TITLE
Allow injecting a strategy for handling invalid replay Ids

### DIFF
--- a/src/CometD.NetCore.Salesforce/IStreamingClient.cs
+++ b/src/CometD.NetCore.Salesforce/IStreamingClient.cs
@@ -15,6 +15,11 @@ namespace CometD.NetCore.Salesforce
         event EventHandler<bool> Reconnect;
 
         /// <summary>
+        /// Inject a strategy for handling invalid replay ids. 
+        /// </summary>
+        Action<int> InvalidReplayIdStrategy { get; set; }
+
+        /// <summary>
         /// True/False if the <see cref="IStreamingClient"/> is connected.
         /// </summary>
         bool IsConnected { get; }

--- a/src/CometD.NetCore.Salesforce/ResilientStreamingClient.cs
+++ b/src/CometD.NetCore.Salesforce/ResilientStreamingClient.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
 using System.Net;
 using System.Threading;
 

--- a/src/CometD.NetCore.Salesforce/ResilientStreamingClient.cs
+++ b/src/CometD.NetCore.Salesforce/ResilientStreamingClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Net;
 using System.Threading;
 
@@ -30,6 +31,8 @@ namespace CometD.NetCore.Salesforce
         private ErrorExtension? _errorExtension;
         private LongPollingTransport? _clientTransport;
         private ReplayExtension? _replayIdExtension;
+
+        public Action<int> InvalidReplayIdStrategy { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ResilientStreamingClient"/> class.
@@ -265,6 +268,19 @@ namespace CometD.NetCore.Salesforce
 
                 // 4. Invoke the Reconnect Event
                 Reconnect?.Invoke(this, true);
+            }
+            else if (e.Contains("you provided was invalid"))
+            {
+                var start = e.IndexOf('{');
+                var end = e.IndexOf('}');
+                var replayIdString = e.Substring(start + 1, end - (start + 1));
+
+                var success = int.TryParse(replayIdString, out var replayId);
+
+                if (success)
+                {
+                    InvalidReplayIdStrategy(replayId);
+                }
             }
             else
             {


### PR DESCRIPTION
Maybe this goes a bit too far of what you want to handle in your library, but some kind of callback is needed for the `ResilientStreamingClient`.

This implementation handles the occurrence of invalid replay Id error from the bus and allows the user to inject a strategy into the client how to handle this error. 