### PR TITLE
Detect '401::Authentication invalid' error received by BayeuxClient as a connectivity problem

### DIFF
--- a/src/CometD.NetCore.Salesforce/ResilientStreamingClient.cs
+++ b/src/CometD.NetCore.Salesforce/ResilientStreamingClient.cs
@@ -209,7 +209,8 @@ namespace CometD.NetCore.Salesforce
             // authentication failure
             if (string.Equals(e, "403::Handshake denied", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(e, "403:denied_by_security_policy:create_denied", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(e, "403::unknown client", StringComparison.OrdinalIgnoreCase))
+                || string.Equals(e, "403::unknown client", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(e, "401::Authentication invalid", StringComparison.OrdinalIgnoreCase))
             {
                 _logger.LogWarning("Handled CometD Exception: {message}", e);
 


### PR DESCRIPTION
@kdcllc,
Fix for [https://github.com/kdcllc/CometD.NetCore.Salesforce/issues/23](url)